### PR TITLE
Fix pedersen commitment definition + properties.

### DIFF
--- a/zk-knowledge.md
+++ b/zk-knowledge.md
@@ -1290,10 +1290,10 @@ by default.
 
 #### Pedersen Commitments
 - Let $$G$$ and $$H$$ be two public generators for a large group where the discrete log is hard.
-- For an input, $$x$$, and hidden random value, $$r$$, the Pedersen commitment is $$comm(x) = xG + rH$$
+- For an input, $$x$$, and hidden random value, $$r$$, the Pedersen commitment is $$comm(x) = G^x + H^r$$
 - The commitment is opened by revealing $$x$$ and $$r$$
 - These have some cool properties compared with hash commitments:
-    - **Additively Homomorphic:** $$comm(a) + comm(b) = comm(a+b)$$
+    - **Additively Homomorphic:** $$comm(a) x comm(b) = comm(a+b)$$
     - **Batchable:** $$x_1G_1 + x_2G_2 + ... + rH = \vec{x}\vec{G} + rH$$
 - Low-level tech: discrete log group
 - Assumptions: discrete log


### PR DESCRIPTION
Hi Delendum. Thanks for all the effort putting together your knowledge base it's been really helpful.

Was going through the Proof Systems > Commitment Schemes > Pedersen Commitments section and think I might have found a few mistake. 

I watched the two resources you provided.

>    Lecture by Dan Boneh: https://youtu.be/IkNZWJFcfcU
>    Overview by Bill Buchanan: https://youtu.be/J9SOk9dIOCk

Both define the pedersen commitment for input `x` and random value `r`  to be `comm(x) = G^x + H^r`, for public generators G and H, rather than `comm(x) = xG + rH`.

And the homomorphic property is `comm(a) x comm(b) = comm(a + b)` - using the product of the commitments, rather than the sum. Would this still be called "additively homomorphic"?

And I'm not sure if the batchable property still holds?

Also, I'm humbly going through cryptographic commitment schemes for the first time so sorry if I'm wrong 😬 

Hope I'm not stepping on any toes. And thanks again!